### PR TITLE
Add retry to data fetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@ To start fetching data into your application, you will need to authorise a sessi
 The authorisation flow is separated into two phases:
 
 Initialise a session with Digi.me API which returns a session object.
-    ```javascript
+```javascript
     establishSession = async (appId: string, contractId: string, options: DigiMeSDKConfiguration): Promise<Session>;
-    ```
+```
 
 ### Getting User Consent
 In digi.me we provide two different ways to prompt user for consent
@@ -59,12 +59,37 @@ In digi.me we provide two different ways to prompt user for consent
 Regardless of which mode above you've trigger, the callbackURL will be triggered once the user has authorised the consent. The callbackURL will be triggered with a new param `result` where the value will either be `DATA_READY` or `CANCELLED` if the user decided to deny the request.
 
 ### Fetching Data
-Upon successful authorisation you can now request user's files. To fetch all available data for your contract you can call getDataForSession to start your data fetch. You'll need to provide us with a private key with which we will try and decrypt user data. In addition you can pass a fileCallback which will be triggered whenever a user data file is processed and returned to the user.
+Upon successful authorisation you can now request user's files. To fetch all available data for your contract you can call `getDataForSession` to start your data fetch. You'll need to provide us with a private key with which we will try and decrypt user data. In addition you can pass a onFileData and onFileError which will be triggered whenever a user data file is processed or if the fetch errored out.
 ```javascript
 getDataForSession = async (
     sessionKey: string,
     privateKey: NodeRSA.Key,
-    fileCallback: FileCallback,
+    onFileData: FileSuccessHandler,
+    onFileError: FileErrorHandler,
     options: DigiMeSDKConfiguration
 ): Promise<any>;
+```
+
+The `onFileData` callback function is triggered whenever we have received data from the server. The content is passed back in files, so this function will be triggered whenever we have received data from one file. The callback will be triggered with an object in the parameter. The object has the following properties: 
+    1. fileData - JSON string of data objects
+    2. fileName - the filename which the objects reside in
+    3. fileList - the list of all files that are to be returned
+```javascript
+callback = ({
+    fileData: any, 
+    fileName: string, 
+    fileList: string[],
+}): void;
+```
+
+The `onFileError` callback function is triggered whenever we have failed to receive any data for the data file. By default, we try to fetch the data five times with exponential backoff before invoking the error callback. The error callback will be triggered with an object in the parameter. The object has the following properties: 
+    1. error - error object
+    2. fileName - the filename which the objects reside in
+    3. fileList - the list of all files that are to be returned
+```javascript
+callback = ({
+    error: Error, 
+    fileName: string, 
+    fileList: string[],
+}): void;
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,11 @@
         }
       }
     },
+    "@lifeomic/attempt": {
+      "version": "3.0.0",
+      "resolved": "https://tools.sysdigi.net/npm/@lifeomic%2fattempt/-/attempt-3.0.0.tgz",
+      "integrity": "sha512-Ibk4Vfl46dSrhtH5fHsrTA4waAuyP7/qcr3uo0mO70azRc6LWgJILlMy3B1oOvyiN9jQcdqwsThaQkPKLiYKTg=="
+    },
     "@sindresorhus/is": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.11.0.tgz",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "typescript": "~3.1.1"
   },
   "dependencies": {
+    "@lifeomic/attempt": "~3.0.0",
     "got": "~9.2.2",
     "lodash.isfunction": "~3.0.9",
     "lodash.isinteger": "~4.0.4",


### PR DESCRIPTION
This commit will add exponential backoff retry logic to the data fetch
calls. The default is 750ms backoff, and everytime it fails, we will
double the wait time up to a maximum of five attempts.

Also added in this commit is the return of the file name and file list as params in the file call back.

[DIGI-12397]