### PR TITLE
Exposing getFile and getFilesList functions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -17,4 +17,6 @@ export const {
     getCreatePostboxUrl,
     pushDataToPostbox,
     getPostboxImportUrl,
+    getFile,
+    getFileList,
 } = init();

--- a/src/sdk-version.ts
+++ b/src/sdk-version.ts
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2009-2019 digi.me Limited. All rights reserved.
- */
+* Copyright (c) 2009-2019 digi.me Limited. All rights reserved.
+*/
 
 export default "1.0.0";


### PR DESCRIPTION
Along with exposure of those two functions, improvements on getSessionAccounts function where response is crypted. From now on, in order to fetch accounts, response must be decrypted with privateKey.