### PR TITLE
Make code verifier an optional param

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Regardless of which mode above you trigger, the `callbackUrl` will be triggered 
 ### 5. Fetching Data
 Upon user consent you can now request user's files. To fetch all available data for your contract you can call `getSessionData` to start your data fetch. You'll need to provide us with a private key with which the SDK will try and decrypt user data. The private key is linked to the contract which you would have received when you obtained the contract ID. In addition you can pass callbacks `onFileData` and `onFileError` which will be triggered whenever a user data file is processed or if the fetch errored out.
 
-This function will return an object containing a promise and which will resolve when all the files are fetched and a function which you can trigger to stop the data fetch process.
+This function will return an object containing a promise which will resolve when all the files are fetched and a function which you can trigger to stop the data fetch process.
 ```typescript
 import { getSessionData } from "@digime/digime-js-sdk";
 

--- a/docs/ongoing-authorization.md
+++ b/docs/ongoing-authorization.md
@@ -50,7 +50,7 @@ Once you call the deep link provided in step 2, the digi.me application will ope
 `state`: Any value you used in Step 1 is now passed back to you should you need to identify the user.
 
 ### Step 4 - Exchange for a user access token
-Once we've received a code from the user consent, we can call `exchangeCodeForToken()` to exchange this with an access token. To do this, we will also need the code verifier which we received in Step 1. The access token can be persisted for future use if we want to access data for this user again in the future. The access token will expire however, in which case, the user will need to consent the request using the digi.me application again.
+Once we've received a code from the user consent, we can call `exchangeCodeForToken()` to exchange this with an access token. To do this, we will also need the code verifier which we received in Step 1. If you don't have the code verifier, you can leave this out. The access token can be persisted for future use if we want to access data for this user again in the future. The access token will expire however, in which case, the user will need to consent the request using the digi.me application again.
 
 ### Subsequent requests
 If we already have an access token for the user, we can start at step 1 again, but passing the user token into the [authorizeOngoingAccess()](#AuthorizeOngoingAccess) method. If the request is successful, you can go directly to [fetch user data](./session-data.md)

--- a/src/cyclic-ca.ts
+++ b/src/cyclic-ca.ts
@@ -144,8 +144,8 @@ const preauthorize = async (
 
 const exchangeCodeForToken = async (
     config: OngoingAccessConfiguration,
-    codeVerifier: string,
     authorizationCode: string,
+    codeVerifier: string | undefined,
     options: DMESDKConfiguration,
 ): Promise<UserAccessToken> => {
 
@@ -163,9 +163,13 @@ const exchangeCodeForToken = async (
         throw new TypeValidationError("Details should be a plain object that contains the properties applicationId, contractId, privateKey and redirectUri");
     }
 
-    if (!isValidString(codeVerifier) || !isValidString(authorizationCode)) {
+    if (typeof codeVerifier !== 'undefined' && !isValidString(codeVerifier)) {
+        throw new TypeValidationError("Code verifier must be empty or a string");
+    }
+
+    if (!isValidString(authorizationCode)) {
         // tslint:disable-next-line:max-line-length
-        throw new TypeValidationError("Code verifier and authorization code cannot be empty");
+        throw new TypeValidationError("Authorization code cannot be empty");
     }
 
     const jwt: string = sign(

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -348,10 +348,10 @@ const init = (sdkOptions?: Partial<DMESDKConfiguration>) => {
             ),
         exchangeCodeForToken: (
             details: OngoingAccessConfiguration,
-            codeVerifier: string,
             authorizationCode: string,
+            codeVerifier?: string,
         ) => (
-                exchangeCodeForToken(details, codeVerifier, authorizationCode, options)
+                exchangeCodeForToken(details, authorizationCode, codeVerifier, options)
             ),
         getSessionAccounts: (
             sessionKey: string,


### PR DESCRIPTION
This commit removes the need for code verifier to be passed in to the exchangeCodeForToken function.

When the user led consent flow is run, this variable is not set, so removing this allows this flow to work.