### PR TITLE
Updated type checks for raw data

### DIFF
--- a/fixtures/network/get-file/valid-files.json
+++ b/fixtures/network/get-file/valid-files.json
@@ -104,11 +104,11 @@
             ],
             "fileContent": "test",
             "fileMetadata": {
-                "objectCount": 1,
-                "objectType": "media",
-                "serviceGroup": "social",
-                "serviceName": "instagram",
-                "mimetype": "text/plain"
+                "mimetype": "text/plain",
+                "accounts": [
+                    { "accountid": "test-account-1" },
+                    { "accountid": "test-account-2" }
+                ]
             }
         }
     },
@@ -126,11 +126,11 @@
             ],
             "fileContent": "test",
             "fileMetadata": {
-                "objectCount": 1,
-                "objectType": "media",
-                "serviceGroup": "social",
-                "serviceName": "instagram",
-                "mimetype": "text/plain"
+                "mimetype": "text/plain",
+                "accounts": [
+                    { "accountid": "test-account-1" },
+                    { "accountid": "test-account-2" }
+                ]
             }
         }
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,7 @@
  */
 
 import NodeRSA from "node-rsa";
+import { MappedFileMetadata, RawFileMetadata } from "./types/api/ca-file-response";
 
 export interface PrivateShareConfiguration {
     applicationId: string;
@@ -47,12 +48,7 @@ export interface ServiceObject {
 export interface FileMeta {
     fileData: any;
     fileName: string;
-    fileMetadata: {
-        objectCount: number;
-        objectType: string;
-        serviceGroup: string;
-        serviceName: string;
-    };
+    fileMetadata: MappedFileMetadata | RawFileMetadata;
 }
 
 export interface PushedFileMeta {

--- a/src/types/api/ca-file-response.spec.ts
+++ b/src/types/api/ca-file-response.spec.ts
@@ -173,7 +173,6 @@ describe("isCAFileResponse", () => {
                 const actual = isCAFileResponse({
                     fileContent: "test",
                     fileMetadata: {
-                        ...validFileMetadata,
                         mimetype: value,
                     },
                 });
@@ -341,8 +340,22 @@ describe("assertIsCAFileResponse", () => {
                 const actual = () => assertIsCAFileResponse({
                     fileContent: "test",
                     fileMetadata: {
-                        ...validFileMetadata,
                         mimetype: value,
+                    },
+                });
+                expect(actual).toThrow(TypeValidationError);
+            },
+        );
+    });
+
+    describe("Throws TypeValidationError when the accounts property of the fileMetadata object is present but not an array", () => {
+        it.each([true, false, null, "Test string", 0, NaN, {}, () => null, Symbol("test")])(
+            "%p",
+            (value: any) => {
+                const actual = () => assertIsCAFileResponse({
+                    fileContent: "test",
+                    fileMetadata: {
+                        accounts: value,
                     },
                 });
                 expect(actual).toThrow(TypeValidationError);
@@ -361,5 +374,4 @@ describe("assertIsCAFileResponse", () => {
         expect(actual).toThrow(TypeValidationError);
         expect(actual).toThrow(/^Test start ([\s\S]*)? test end$/);
     });
-
 });


### PR DESCRIPTION
This commit updates the dynamic type checks to allow for file metadata
of raw data types. This was failing before since the metadata format is
slightly different to mapped data.