### PR TITLE
Continue polling on library pending

### DIFF
--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -200,7 +200,8 @@ const _getSessionData = (
             state = status.state;
 
             if (state === "pending") {
-                break;
+                await sleep(3000);
+                continue;
             }
 
             const newFiles: string[] = (fileList || []).reduce((accumulator: string[], file) => {


### PR DESCRIPTION
This commit updates the getSessionData function to continue polling when we receive a pending status from server. Before this release, when a third party calls getSessionData and if the status is pending, we would simply quit the call.

With the introduction of CA MQ (Consent Access Message Queue) on the server, there might be a slight delay when the digi.me client triggers the data query to when the library status returns running. We therefore need to update the SDK so that getSessionData continues polling even when receiving a pending status.